### PR TITLE
Generate MLP lecture notes, practice exam, and from-scratch notebook

### DIFF
--- a/mlp_from_scratch.ipynb
+++ b/mlp_from_scratch.ipynb
@@ -1,0 +1,273 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Building a Multi-Layer Perceptron from Scratch in NumPy\n",
+    "\n",
+    "**Objective:** This notebook implements a Multi-Layer Perceptron (MLP) from scratch using only NumPy. The goal is to demonstrate the mechanics of forward and backward propagation for a simple regression task, based on the MLP architecture discussed in the lecture exercise."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Activation Functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def sigmoid(x):\n",
+    "    return 1 / (1 + np.exp(-x))\n",
+    "\n",
+    "def sigmoid_derivative(x):\n",
+    "    s = sigmoid(x)\n",
+    "    return s * (1 - s)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## MLP Class"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class MLP:\n",
+    "    def __init__(self):\n",
+    "        # Weights from the exercise sheet diagram\n",
+    "        # W1: (3 inputs + 1 bias) x 2 hidden neurons\n",
+    "        # W2: (2 hidden neurons + 1 bias) x 1 output neuron\n",
+    "        # The exercise diagram implies weights are for connections, biases are separate\n",
+    "        self.W1 = np.array([[0.1, 0.4],\n",
+    "                              [0.2, 0.5],\n",
+    "                              [0.3, 0.6]]) # Shape (3, 2)\n",
+    "        self.b1 = np.zeros((1, 2)) # Shape (1, 2) for 2 hidden neurons\n",
+    "\n",
+    "        self.W2 = np.array([[0.7],\n",
+    "                              [0.8]]) # Shape (2, 1)\n",
+    "        self.b2 = np.zeros((1, 1)) # Shape (1, 1) for 1 output neuron\n",
+    "\n",
+    "        # Attributes to store intermediate values for backpropagation\n",
+    "        self.z1 = None # Input to hidden layer activation\n",
+    "        self.h1 = None # Output of hidden layer activation\n",
+    "        self.z2 = None # Input to output layer activation\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        # x is expected to be a column vector (e.g., shape (3,1) for 3 input features)\n",
+    "        # Ensure x is a 2D array for consistent matrix multiplication\n",
+    "        if x.ndim == 1:\n",
+    "            x = x.reshape(-1, 1)\n",
+    "        \n",
+    "        # Hidden layer\n",
+    "        # z = Wx + b. Here x is (num_features, 1), W1 is (num_hidden_units, num_features)\n",
+    "        # To match exercise: W1 (features, hidden_units), x (features, 1). So x.T @ W1 or W1.T @ x\n",
+    "        # Let's assume W1 is (input_dim, hidden_dim) and W2 is (hidden_dim, output_dim)\n",
+    "        # Input x shape: (num_samples, num_input_features)\n",
+    "        # self.W1 shape: (num_input_features, num_hidden_neurons)\n",
+    "        # self.b1 shape: (1, num_hidden_neurons)\n",
+    "        self.z1 = np.dot(x.T, self.W1) + self.b1 # z1 shape: (1, num_hidden_neurons)\n",
+    "        self.h1 = sigmoid(self.z1) # h1 shape: (1, num_hidden_neurons)\n",
+    "\n",
+    "        # Output layer\n",
+    "        # self.W2 shape: (num_hidden_neurons, num_output_neurons)\n",
+    "        # self.b2 shape: (1, num_output_neurons)\n",
+    "        self.z2 = np.dot(self.h1, self.W2) + self.b2 # z2 shape: (1, num_output_neurons)\n",
+    "        y_hat = sigmoid(self.z2) # y_hat shape: (1, num_output_neurons)\n",
+    "        \n",
+    "        return y_hat\n",
+    "\n",
+    "    def backward(self, x, y, y_hat):\n",
+    "        # x shape: (num_input_features, 1) or (num_samples, num_input_features)\n",
+    "        # y, y_hat shape: (1, num_output_neurons) or (num_samples, num_output_neurons)\n",
+    "        # Ensure x is a 2D array for consistent operations\n",
+    "        if x.ndim == 1:\n",
+    "            x = x.reshape(-1, 1)\n",
+    "            \n",
+    "        # Ensure y and y_hat are 2D arrays like (1,1)\n",
+    "        if not isinstance(y, np.ndarray) or y.ndim == 0 or y.ndim == 1:\n",
+    "            y = np.array([[y]])\n",
+    "        if not isinstance(y_hat, np.ndarray) or y_hat.ndim == 0 or y_hat.ndim == 1:\n",
+    "            y_hat = np.array([[y_hat]])\n",
+    "\n",
+    "        # MSE Loss: L = 0.5 * (y_hat - y)^2\n",
+    "        # dL/dy_hat = y_hat - y\n",
+    "        \n",
+    "        # Output layer gradients (Layer 2)\n",
+    "        # delta2 = dL/dz2 = dL/dy_hat * dy_hat/dz2\n",
+    "        # dy_hat/dz2 = sigmoid_derivative(z2)\n",
+    "        delta2 = (y_hat - y) * sigmoid_derivative(self.z2) # shape (1, num_output_neurons)\n",
+    "\n",
+    "        # dL/dW2 = dL/dz2 * dz2/dW2 = delta2 * h1.T\n",
+    "        # self.h1 shape (1, num_hidden_neurons), delta2 shape (1, num_output_neurons)\n",
+    "        # dW2 shape must be same as W2: (num_hidden_neurons, num_output_neurons)\n",
+    "        dW2 = np.dot(self.h1.T, delta2) # (hidden, 1) @ (1, output) -> (hidden, output)\n",
+    "\n",
+    "        # dL/db2 = dL/dz2 * dz2/db2 = delta2 * 1\n",
+    "        db2 = np.sum(delta2, axis=0, keepdims=True) # Sum over samples if batch > 1, here it's (1, output)\n",
+    "\n",
+    "        # Hidden layer gradients (Layer 1)\n",
+    "        # delta1 = dL/dz1 = (dL/dz2 * dz2/dh1) * dh1/dz1\n",
+    "        # dL/dz2 * dz2/dh1 = delta2 @ W2.T\n",
+    "        # dh1/dz1 = sigmoid_derivative(z1)\n",
+    "        # delta2 shape (1, num_output_neurons), self.W2.T shape (num_output_neurons, num_hidden_neurons)\n",
+    "        delta1 = np.dot(delta2, self.W2.T) * sigmoid_derivative(self.z1) # shape (1, num_hidden_neurons)\n",
+    "\n",
+    "        # dL/dW1 = dL/dz1 * dz1/dW1 = delta1 * x.T\n",
+    "        # x.T shape (1, num_input_features), delta1 shape (1, num_hidden_neurons)\n",
+    "        # dW1 shape must be same as W1: (num_input_features, num_hidden_neurons)\n",
+    "        # x has been transposed if it was a column vector for forward pass input\n",
+    "        # If x was (features, 1), x.T is (1, features). Here we need (features, 1) @ (1, hidden)\n",
+    "        dW1 = np.dot(x, delta1) # (features, 1) @ (1, hidden) -> (features, hidden)\n",
+    "        \n",
+    "        # dL/db1 = dL/dz1 * dz1/db1 = delta1 * 1\n",
+    "        db1 = np.sum(delta1, axis=0, keepdims=True) # Sum over samples if batch > 1, here (1, hidden)\n",
+    "\n",
+    "        return dW2, db2, dW1, db1\n",
+    "\n",
+    "    def update_params(self, dW2, db2, dW1, db1, learning_rate):\n",
+    "        self.W2 -= learning_rate * dW2\n",
+    "        self.b2 -= learning_rate * db2\n",
+    "        self.W1 -= learning_rate * dW1\n",
+    "        self.b1 -= learning_rate * db1\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Training Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mlp = MLP()\n",
+    "\n",
+    "learning_rate = 0.1\n",
+    "epochs = 1000\n",
+    "\n",
+    "# Training sample from the exercise (page with forward pass example)\n",
+    "# x = [x1, x2, x3] = [36, 70, 1]\n",
+    "# y = 1 (target output)\n",
+    "x_train = np.array([[36], [70], [1]]) # Shape (3, 1)\n",
+    "y_train = 1 # Target scalar value\n",
+    "\n",
+    "loss_history = []"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Training Loop"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for epoch in range(epochs):\n",
+    "    # Forward pass\n",
+    "    # The forward method expects x_train.T if x_train is (features, 1)\n",
+    "    # Or it handles x_train directly if it's (1, features) or (features, 1) and transposes internally\n",
+    "    # Let's make sure input to forward is (num_samples, num_features) = (1,3) for our single sample\n",
+    "    # The current forward pass expects x.T to be (1,3) if W1 is (3,2)\n",
+    "    # So x should be (3,1) which is current x_train shape.\n",
+    "    y_hat = mlp.forward(x_train) # y_hat will be (1,1)\n",
+    "    \n",
+    "    # Calculate MSE loss\n",
+    "    loss = 0.5 * (y_hat - y_train)**2\n",
+    "    loss_history.append(loss.item()) # .item() to get scalar from (1,1) array\n",
+    "    \n",
+    "    # Backward pass\n",
+    "    # backward expects x_train (3,1), y_train (scalar), y_hat (1,1)\n",
+    "    dW2, db2, dW1, db1 = mlp.backward(x_train, y_train, y_hat)\n",
+    "    \n",
+    "    # Update parameters\n",
+    "    mlp.update_params(dW2, db2, dW1, db1, learning_rate)\n",
+    "    \n",
+    "    if (epoch + 1) % 100 == 0:\n",
+    "        print(f'Epoch {epoch+1}/{epochs}, Loss: {loss.item():.6f}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Results and Visualization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(10, 6))\n",
+    "plt.plot(range(epochs), loss_history)\n",
+    "plt.title('Training Loss Over Epochs')\n",
+    "plt.xlabel('Epochs')\n",
+    "plt.ylabel('MSE Loss')\n",
+    "plt.grid(True)\n",
+    "plt.show()\n",
+    "\n",
+    "print(\"\\nFinal Trained Weights and Biases:\")\n",
+    "print(\"W1:\", mlp.W1)\n",
+    "print(\"b1:\", mlp.b1)\n",
+    "print(\"W2:\", mlp.W2)\n",
+    "print(\"b2:\", mlp.b2)\n",
+    "\n",
+    "final_prediction = mlp.forward(x_train)\n",
+    "print(f\"\\nFinal prediction for x_train = {x_train.T.tolist()}: {final_prediction.item():.6f}\")\n",
+    "print(f\"Target value y_train: {y_train}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/mlp_lecture_notes.md
+++ b/mlp_lecture_notes.md
@@ -1,0 +1,242 @@
+# Deep Learning: Multi-Layer Perceptron (MLP)
+
+## Overview
+
+This document provides a comprehensive overview of Multi-Layer Perceptrons (MLPs), covering the following key topics:
+*   Limitations of linear models and the need for MLPs.
+*   The crucial role of non-linear activation functions.
+*   Mathematical demonstration that stacking linear layers is insufficient.
+*   Commonly used activation functions: Sigmoid, Tanh, ReLU, Leaky ReLU, ELU, Swish, GELU.
+*   Architecture of MLPs: Input, Hidden, and Output Layers.
+*   Forward propagation in an L-layer network.
+*   Tailoring MLP architecture for classification and regression tasks.
+*   The Universal Approximation Theorem and its implications.
+*   Model training using gradient-based optimization and the Backpropagation algorithm.
+*   Detailed mathematical derivation of backpropagation for a 2-layer network.
+*   General backpropagation equations for an L-layer network.
+
+## From Softmax Regression to MLPs
+
+Linear models like Softmax Regression (for classification) or Linear Regression (for regression) are fundamental in machine learning. They model a direct, linear relationship between the input features and the output. For an input vector $x$, a linear model computes an output $y$ (or scores for classes) using a linear transformation: $y = W^T x + b$, where $W$ represents the weights and $b$ is the bias.
+
+**Limitation of Linear Models:**
+The primary limitation of these models is that they can only capture **affine-linear relationships**. If the underlying relationship between the input features and the target variable is non-linear, linear models will perform poorly as they lack the capacity to represent such complexities.
+
+**Stacking Layers for Increased Complexity:**
+To overcome this limitation and enable models to learn more complex, non-linear patterns, the concept of stacking layers is introduced. The idea is that by adding more layers of computation, the model can build up more intricate representations of the data. A Multi-Layer Perceptron (MLP) is formed by stacking one or more "hidden" layers between the input and output layers.
+
+**Crucial Point: Stacking Linear Layers Results in an Equivalent Linear Layer**
+
+A common misconception might be that simply adding more linear layers (i.e., layers without a non-linear activation function) will increase the model's expressive power to capture non-linearities. However, this is not the case. Stacking multiple linear layers is mathematically equivalent to a single linear layer.
+
+Let's demonstrate this for a two-layer network.
+Consider an input vector $x$.
+The output of the first linear layer, $h^{(1)}$, is:
+$h^{(1)} = W^{(1)T} x + b^{(1)}$
+
+Now, if we feed this output $h^{(1)}$ into a second linear layer to get the final output $y$:
+$y = W^{(2)T} h^{(1)} + b^{(2)}$
+
+Substitute the expression for $h^{(1)}$ into the second equation:
+$y = W^{(2)T} (W^{(1)T} x + b^{(1)}) + b^{(2)}$
+$y = W^{(2)T} W^{(1)T} x + W^{(2)T} b^{(1)} + b^{(2)}$
+
+Let $W_{eff}^T = W^{(2)T} W^{(1)T}$. This means $W_{eff} = (W^{(1)} W^{(2)})^T$.
+And let $b_{eff} = W^{(2)T} b^{(1)} + b^{(2)}$.
+
+Then the equation for $y$ becomes:
+$y = W_{eff}^T x + b_{eff}$
+
+This final equation is in the same form as a single linear layer ($Wx+b$ or $W^Tx+b$). Therefore, no matter how many linear layers we stack, the resulting model is still just a linear model. It cannot learn non-linear relationships. This highlights the necessity of introducing non-linearity into the network, which is achieved through activation functions.
+
+## The Role of Non-Linear Activation Functions
+
+To enable MLPs to model complex, non-linear relationships, a **non-linear activation function** is applied after the linear transformation in each hidden layer (and often in the output layer, depending on the task).
+
+If $z^{(l)}$ is the linear output of layer $l$ (where $h^{(l-1)}$ is the output of the previous layer), computed as $z^{(l)} = W^{(l)} h^{(l-1)} + b^{(l)}$ (using the convention where $W^{(l)}$ is $n_l \times n_{l-1}$), the activation function $f^{(l)}$ is applied to $z^{(l)}$ to produce the layer's output $h^{(l)}$:
+$h^{(l)} = f^{(l)}(z^{(l)})$
+
+**Desirable Properties for Activation Functions:**
+When choosing an activation function, several properties are desirable:
+1.  **Non-linearity:** This is crucial, as discussed above, to allow the network to learn complex patterns.
+2.  **Differentiability:** Activation functions need to be differentiable (or at least mostly differentiable) to enable gradient-based optimization methods like backpropagation. The derivative allows us to understand how changes in the function's input affect its output, which is essential for updating the model's weights.
+3.  **Easily Computable Derivatives:** Since derivatives are calculated frequently during training, it's important that they are computationally efficient to calculate.
+4.  **Avoidance of Saturation:** Some activation functions (like sigmoid and tanh) saturate for very large positive or negative inputs, meaning their output becomes flat. In these flat regions, the gradient is close to zero. This can lead to the "vanishing gradient" problem.
+5.  **Zero-Centered Output (for some functions):** Functions like tanh that produce outputs centered around zero can sometimes help in speeding up convergence.
+6.  **Non-dying Neurons:** Functions like ReLU can cause neurons to "die" if their input consistently falls into a region where the gradient is zero. Variants like Leaky ReLU address this.
+
+### Commonly Used Activation Functions
+
+Here are some commonly used activation functions in deep learning:
+
+#### 1. Sigmoid (Logistic)
+*   **Mathematical Formula:**
+    $\sigma(x) = \frac{1}{1 + e^{-x}}$
+*   **Derivative's Formula:**
+    $\sigma'(x) = \sigma(x)(1 - \sigma(x))$
+*   **Characteristics:**
+    -   Outputs values between 0 and 1.
+    -   Used for binary classification output probability.
+    -   Suffers from vanishing gradients due to saturation.
+    -   Output is not zero-centered.
+
+#### 2. Hyperbolic Tangent (Tanh)
+*   **Mathematical Formula:**
+    $\tanh(x) = \frac{e^x - e^{-x}}{e^x + e^{-x}} = 2\sigma(2x) - 1$
+*   **Derivative's Formula:**
+    $\tanh'(x) = 1 - \tanh^2(x)$
+*   **Characteristics:**
+    -   Outputs values between -1 and 1.
+    -   Zero-centered output.
+    -   Still suffers from saturation, but generally preferred over sigmoid in hidden layers if saturation is a concern and zero-centering is desired.
+
+#### 3. Rectified Linear Unit (ReLU)
+*   **Mathematical Formula:**
+    $\text{ReLU}(x) = \max(0, x)$
+*   **Derivative's Formula:**
+    $\text{ReLU}'(x) = \begin{cases} 1 & \text{if } x > 0 \\ 0 & \text{if } x \le 0 \end{cases}$
+*   **Characteristics:**
+    -   Non-linear, computationally efficient.
+    -   Alleviates vanishing gradient for $x>0$.
+    -   Can suffer from "dying ReLU" problem (neurons get stuck at output 0).
+    -   Not zero-centered. Most popular activation for hidden layers.
+
+#### 4. Leaky ReLU (LReLU)
+*   **Mathematical Formula:**
+    $\text{LReLU}(x) = \begin{cases} x & \text{if } x > 0 \\ \alpha x & \text{if } x \le 0 \end{cases}$ (e.g., $\alpha=0.01$)
+*   **Derivative's Formula:**
+    $\text{LReLU}'(x) = \begin{cases} 1 & \text{if } x > 0 \\ \alpha & \text{if } x \le 0 \end{cases}$
+*   **Characteristics:**
+    -   Fixes dying ReLU by allowing a small non-zero gradient for negative inputs.
+    -   Parametric ReLU (PReLU) learns $\alpha$.
+
+#### 5. Exponential Linear Unit (ELU)
+*   **Mathematical Formula:**
+    $\text{ELU}(x) = \begin{cases} x & \text{if } x > 0 \\ \alpha (e^x - 1) & \text{if } x \le 0 \end{cases}$ (e.g., $\alpha=1.0$)
+*   **Derivative's Formula:**
+    $\text{ELU}'(x) = \begin{cases} 1 & \text{if } x > 0 \\ \alpha e^x & \text{if } x \le 0 \end{cases}$ (which is $\text{ELU}(x) + \alpha$ for $x \le 0$)
+*   **Characteristics:**
+    -   Outputs can be negative, closer to zero-mean.
+    -   More computationally expensive than ReLU.
+    -   Can lead to faster learning and better generalization.
+
+#### 6. Swish (SiLU - Sigmoid Linear Unit when $\beta=1$)
+*   **Mathematical Formula:**
+    $\text{Swish}(x) = x \cdot \sigma(\beta x) = \frac{x}{1 + e^{-\beta x}}$
+*   **Derivative's Formula:**
+    $\text{Swish}'(x) = \text{Swish}(x) + \sigma(\beta x)(1 - \text{Swish}(x))$
+*   **Characteristics:**
+    -   Smooth, non-monotonic. Outperforms ReLU on deeper models.
+    -   More computationally expensive.
+
+#### 7. Gaussian Error Linear Unit (GELU)
+*   **Mathematical Formula:**
+    $\text{GELU}(x) = x \cdot \Phi(x)$, where $\Phi(x)$ is the CDF of the standard normal distribution.
+    Approximation: $0.5x \left(1 + \tanh\left[\sqrt{2/\pi}(x + 0.044715x^3)\right]\right)$
+*   **Derivative's Formula:**
+    $\text{GELU}'(x) = \Phi(x) + x \phi(x)$, where $\phi(x)$ is PDF of standard normal.
+*   **Characteristics:**
+    -   Smooth approximation of ReLU, non-monotonic.
+    -   Used in models like BERT, GPT. Computationally expensive.
+
+## MLP Architecture and Forward Propagation
+
+An MLP consists of:
+1.  **Input Layer ($h^{(0)} = x$):** Receives input features.
+2.  **Hidden Layers ($l=1, \dots, L-1$):** Perform transformations.
+3.  **Output Layer ($l=L$):** Produces the final prediction.
+
+**Forward Propagation in an L-Layer Network (Slide 12 convention):**
+*   $h^{(0)} = x$: Input vector (shape $n_0 \times 1$).
+*   For each layer $l$ from $1$ to $L$:
+    *   $W^{(l)}$: Weight matrix for layer $l$ (shape $n_l \times n_{l-1}$).
+    *   $b^{(l)}$: Bias vector for layer $l$ (shape $n_l \times 1$).
+    *   $z^{(l)}$: Pre-activation (linear combination) for layer $l$:
+        $z^{(l)} = W^{(l)} h^{(l-1)} + b^{(l)}$ (shape $n_l \times 1$)
+    *   $f^{(l)}(\cdot)$: Activation function for layer $l$.
+    *   $h^{(l)}$: Activation (output) of layer $l$:
+        $h^{(l)} = f^{(l)}(z^{(l)})$ (shape $n_l \times 1$)
+
+The final output of the network is $\hat{y} = h^{(L)}$.
+
+**Task-Dependent Architecture and Output Activation:**
+
+**1. MLP for Classification (N classes):**
+*   **Output Layer:** $N$ nodes.
+*   **Activation Function:** **Softmax** function:
+    $\text{Softmax}(z_i^{(L)}) = \frac{e^{z_i^{(L)}}}{\sum_{j=1}^{N} e^{z_j^{(L)}}}$ for $i=1, \dots, N$.
+    Converts logits $z^{(L)}$ into a probability distribution.
+*   **Loss Function:** **Cross-Entropy Loss**. For true one-hot label $y$ and predicted probabilities $\hat{y}$:
+    $L = -\sum_{i=1}^{N} y_i \log(\hat{y}_i)$
+
+**2. MLP for Regression (single output):**
+*   **Output Layer:** One node (or more for multi-target regression).
+*   **Activation Function:** **Linear (identity)** function, $f(z) = z$.
+*   **Loss Function:** **Mean Squared Error (MSE)**. For true value $y$ and prediction $\hat{y}$:
+    $L = \frac{1}{2} (\hat{y} - y)^2$
+
+## Universal Approximation Theorem
+
+**Statement:**
+A feedforward neural network with a single hidden layer containing a finite number of neurons and using a non-linear "squashing" activation function (like sigmoid) can approximate any continuous function on compact subsets of $\mathbb{R}^n$ to any desired degree of accuracy. (ReLU and other non-polynomial activations also work).
+
+**Important Caveats:**
+1.  **Not Constructive:** Doesn't say how many neurons are needed or how to find weights.
+2.  **Approximation Quality:** Fixed neuron count doesn't guarantee quality.
+3.  **Deeper Networks Often Better:** Deep networks can be more efficient and generalize better than shallow, wide ones.
+4.  **Optimization Challenges:** Finding optimal weights is hard.
+5.  **Primary Impact:** Boosted confidence in neural networks' capabilities.
+
+## Model Training: Backpropagation
+
+Models are trained by minimizing a loss function $L$ using gradient-based optimization.
+**Backpropagation** is an algorithm to efficiently compute partial derivatives $\frac{\partial L}{\partial W_{ij}^{(l)}}$ and $\frac{\partial L}{\partial b_i^{(l)}}$ using the chain rule, propagating errors backward from the output layer.
+
+### Detailed Mathematical Derivation (2-Layer Network, MSE Loss, Slide 23)
+
+Consider a 2-layer MLP:
+*   Input $x = h^{(0)}$
+*   Layer 1: $z^{(1)} = W^{(1)}x + b^{(1)}$, $h^{(1)} = f^{(1)}(z^{(1)})$
+*   Layer 2 (Output): $z^{(2)} = W^{(2)}h^{(1)} + b^{(2)}$, $\hat{y} = h^{(2)} = f^{(2)}(z^{(2)})$
+*   Loss: $L = \frac{1}{2} (\hat{y} - y)^2$ (for scalar output $y, \hat{y}$)
+
+**Intermediate Error Term Definition:** $\delta^{(l)} = \frac{\partial L}{\partial z^{(l)}}$
+
+**1. Gradients for Output Layer ($W^{(2)}, b^{(2)}$):**
+*   $\delta^{(2)} = \frac{\partial L}{\partial z^{(2)}} = \frac{\partial L}{\partial \hat{y}} \frac{\partial \hat{y}}{\partial z^{(2)}} = (\hat{y} - y) \cdot f^{(2)'}(z^{(2)})$
+*   $\frac{\partial L}{\partial W_{ij}^{(2)}} = \frac{\partial L}{\partial z_i^{(2)}} \frac{\partial z_i^{(2)}}{\partial W_{ij}^{(2)}} = \delta_i^{(2)} h_j^{(1)}$.
+    In vector form: $\frac{\partial L}{\partial W^{(2)}} = \delta^{(2)} (h^{(1)})^T$
+    (Assuming $W^{(2)}$ is $n_2 \times n_1$, $\delta^{(2)}$ is $n_2 \times 1$, $h^{(1)}$ is $n_1 \times 1$)
+*   $\frac{\partial L}{\partial b^{(2)}} = \delta^{(2)}$
+
+**2. Gradients for Hidden Layer ($W^{(1)}, b^{(1)}$):**
+*   To find $\delta^{(1)} = \frac{\partial L}{\partial z^{(1)}}$:
+    $\delta^{(1)}_k = \sum_i \frac{\partial L}{\partial z_i^{(2)}} \frac{\partial z_i^{(2)}}{\partial h_k^{(1)}} \frac{\partial h_k^{(1)}}{\partial z_k^{(1)}}$
+    $\frac{\partial z_i^{(2)}}{\partial h_k^{(1)}} = W_{ik}^{(2)}$ (element $i,k$ of $W^{(2)}$)
+    $\frac{\partial h_k^{(1)}}{\partial z_k^{(1)}} = f^{(1)'}(z_k^{(1)})$
+    So, $\delta^{(1)}_k = \left( \sum_i W_{ik}^{(2)} \delta_i^{(2)} \right) f^{(1)'}(z_k^{(1)})$
+    In vector form: $\delta^{(1)} = (W^{(2)T} \delta^{(2)}) \odot f^{(1)'}(z^{(1)})$
+    (where $\odot$ is element-wise product. $W^{(2)T}$ is $n_1 \times n_2$, $\delta^{(2)}$ is $n_2 \times 1$, result is $n_1 \times 1$)
+*   $\frac{\partial L}{\partial W_{kj}^{(1)}} = \frac{\partial L}{\partial z_k^{(1)}} \frac{\partial z_k^{(1)}}{\partial W_{kj}^{(1)}} = \delta_k^{(1)} x_j$.
+    In vector form: $\frac{\partial L}{\partial W^{(1)}} = \delta^{(1)} x^T$
+    (Assuming $W^{(1)}$ is $n_1 \times n_0$, $\delta^{(1)}$ is $n_1 \times 1$, $x$ is $n_0 \times 1$)
+*   $\frac{\partial L}{\partial b^{(1)}} = \delta^{(1)}$
+
+This shows $\delta^{(1)}$ can be calculated recursively from $\delta^{(2)}$.
+
+### General Backpropagation Equations (L-Layer Network, Single Sample - Slide 25)
+
+For a single training sample $(x,y)$:
+1.  **Forward Pass:** Compute all $z^{(l)}$ and $h^{(l)}$ for $l=1, \dots, L$. $h^{(0)}=x$.
+2.  **Backward Pass:**
+    *   **Output Layer ($l=L$):**
+        $\delta^{(L)} = \frac{\partial L}{\partial h^{(L)}} \odot f^{(L)'}(z^{(L)})$
+        (Note: For MSE, $\frac{\partial L}{\partial h^{(L)}} = h^{(L)} - y$. For Softmax output layer with Cross-Entropy loss, this entire term $\delta^{(L)}$ conveniently simplifies to $h^{(L)} - y$, where $y$ is the one-hot encoded true label vector.)
+    *   **Hidden Layers ($l = L-1, \dots, 1$):** (Iterating backwards)
+        $\delta^{(l)} = (W^{(l+1)T} \delta^{(l+1)}) \odot f^{(l)'}(z^{(l)})$
+    *   **Gradients:** For $l=L, \dots, 1$:
+        $\frac{\partial L}{\partial W^{(l)}} = \delta^{(l)} (h^{(l-1)})^T$
+        $\frac{\partial L}{\partial b^{(l)}} = \delta^{(l)}$
+
+These gradients are then used to update parameters, e.g., $W^{(l)} \leftarrow W^{(l)} - \eta \frac{\partial L}{\partial W^{(l)}}$, where $\eta$ is the learning rate.
+For batch training (Batch Size $B > 1$), the gradients $\frac{\partial L}{\partial W^{(l)}}$ and $\frac{\partial L}{\partial b^{(l)}}$ are typically averaged over all $B$ samples in the batch before the parameter update step.

--- a/mlp_practice_exam.md
+++ b/mlp_practice_exam.md
@@ -1,0 +1,229 @@
+# MLP Practice Exam
+
+## Section 1: Questions
+
+### Conceptual Questions (Easy/Medium)
+
+1.  Why is simply stacking multiple hidden layers without a non-linear activation function not useful for learning complex patterns? Provide a mathematical justification.
+2.  Explain the Universal Approximation Theorem. What are two of its major practical limitations?
+3.  What is the purpose of the backpropagation algorithm? Why is it preferred over calculating the derivative of the loss function with respect to each weight independently?
+4.  You are building an MLP to predict house prices (a regression task). What activation function would you use in the output layer and what loss function would be appropriate? Why?
+5.  You are building an MLP to classify images into 10 categories (a multi-class classification task). Describe the setup of your output layer (number of nodes, activation function) and a suitable loss function.
+
+### Calculation Questions (Medium/Hard)
+
+**Question 1 (Network Parameters):**
+You design a fully-connected MLP with one input layer, one hidden layer, and one output layer.
+*   The input layer has 10 nodes.
+*   The hidden layer has 20 nodes.
+*   The output layer has 5 nodes.
+Calculate the total number of trainable parameters (weights and biases) in this network. Show your calculations for each layer.
+
+**Question 2 (Forward and Backward Pass - Based on Exercise Sheet):**
+Consider a 3-input, 2-hidden-node, 1-output MLP.
+*   **Network Parameters:**
+    *   Weights from input to hidden layer ($W^{(1)}$):
+        $W^{(1)} = \begin{pmatrix} 0.1 & 0.4 \\ 0.2 & 0.5 \\ 0.3 & 0.6 \end{pmatrix}$
+        (Connecting 3 inputs to 2 hidden nodes. $W_{ij}^{(1)}$ is weight from input $i$ to hidden node $j$)
+    *   Weights from hidden to output layer ($W^{(2)}$):
+        $W^{(2)} = \begin{pmatrix} 0.7 \\ 0.8 \end{pmatrix}$
+        (Connecting 2 hidden nodes to 1 output node. $W_{k}^{(2)}$ is weight from hidden node $k$ to output node)
+    *   Assume all biases ($b^{(1)}, b^{(2)}$) are zero.
+*   **Activation Functions:**
+    *   Hidden layer ($h^{(1)}$): ReLU activation function.
+    *   Output layer ($\hat{y}$): Sigmoid activation function.
+*   **Given:**
+    *   Input vector $x = \begin{pmatrix} 10 \\ 50 \\ -20 \end{pmatrix}$
+    *   Ground-truth label $y = 0$.
+
+**Tasks:**
+*   **a) (Forward Pass):** Perform a complete forward pass. Calculate the values of $z^{(1)}$ (pre-activation hidden), $h^{(1)}$ (activation hidden), $z^{(2)}$ (pre-activation output), and the final prediction $\hat{y}$.
+*   **b) (Loss Calculation):** Calculate the Mean Squared Error (MSE) loss for your prediction. Use the formula $L = \frac{1}{2} (\hat{y} - y)^2$.
+*   **c) (Backward Pass):** Perform a complete backward pass to find the gradients of the loss with respect to all weights, i.e., $\frac{\partial L}{\partial W^{(2)}}$ and $\frac{\partial L}{\partial W^{(1)}}$. Show your intermediate calculations for $\delta^{(2)}$ and $\delta^{(1)}$.
+
+## Section 2: Solutions
+
+### Solutions to Conceptual Questions
+
+1.  **Stacking Linear Layers:**
+    Stacking multiple linear layers without non-linear activation functions is not useful for learning complex patterns because the composition of multiple linear transformations is itself a single linear transformation.
+    *Mathematical Justification:*
+    Let $h^{(1)} = W^{(1)T}x + b^{(1)}$ be the output of the first linear layer.
+    Let $h^{(2)} = W^{(2)T}h^{(1)} + b^{(2)}$ be the output of the second linear layer.
+    Substituting $h^{(1)}$ into the second equation:
+    $h^{(2)} = W^{(2)T}(W^{(1)T}x + b^{(1)}) + b^{(2)}$
+    $h^{(2)} = (W^{(2)T}W^{(1)T})x + (W^{(2)T}b^{(1)} + b^{(2)})$
+    If we define $W_{eff}^T = W^{(2)T}W^{(1)T}$ and $b_{eff} = W^{(2)T}b^{(1)} + b^{(2)}$, then the equation becomes:
+    $h^{(2)} = W_{eff}^T x + b_{eff}$
+    This is the form of a single linear layer. Thus, no amount of stacking linear layers can introduce non-linearity, which is essential for modeling complex relationships in data.
+
+2.  **Universal Approximation Theorem:**
+    The Universal Approximation Theorem states that a feedforward neural network with a single hidden layer containing a finite number of neurons and using a non-linear activation function (like sigmoid or ReLU) can approximate any continuous function on compact subsets of $\mathbb{R}^n$ to an arbitrary degree of accuracy.
+    *Major Practical Limitations:*
+    *   **Non-Constructive:** The theorem doesn't tell us *how many* neurons are needed for a specific function or accuracy, nor does it provide a method to find the optimal weights and biases. The required number of neurons could be impractically large.
+    *   **Optimization Difficulty:** Even if a network with the required capacity exists, training it (i.e., finding the parameters that achieve the desired approximation) can be a very challenging non-convex optimization problem. Deep learning relies on heuristic optimization algorithms like gradient descent, which may not find the global optimum.
+    *   (Also, while one layer is sufficient, deeper networks are often more efficient and generalize better).
+
+3.  **Purpose of Backpropagation:**
+    The purpose of the backpropagation algorithm is to efficiently compute the gradients (partial derivatives) of the loss function with respect to all the parameters (weights and biases) in a neural network.
+    *Why Preferred:*
+    Backpropagation is preferred over calculating each derivative independently because it is much more computationally efficient. It applies the chain rule systematically, starting from the output layer and moving backward. This allows it to reuse computations. For example, the gradient of the loss with respect to a weight in an early layer depends on computations involving gradients from later layers. Backpropagation calculates these "error signals" (deltas) once per layer and propagates them backward, avoiding the redundant calculations that would occur if each $\frac{\partial L}{\partial W_{ij}^{(l)}}$ was computed from scratch. The complexity of backpropagation is roughly proportional to the complexity of a forward pass, making it feasible for large networks.
+
+4.  **MLP for House Price Prediction (Regression):**
+    *   **Output Layer Activation Function:** **Linear (or Identity) activation function**. This is because house prices are continuous values that can range freely (e.g., from thousands to millions) and are not restricted to a specific interval like [0,1] (sigmoid) or a probability distribution (softmax). A linear activation $f(z)=z$ allows the output node to produce any real-valued number.
+    *   **Loss Function:** **Mean Squared Error (MSE)** or Mean Absolute Error (MAE). MSE, $L = \frac{1}{N}\sum (y_i - \hat{y}_i)^2$ (or $L = \frac{1}{2}(y - \hat{y})^2$ for a single sample), is commonly used because it penalizes larger errors more heavily and is differentiable, which is good for gradient-based optimization. MAE, $L = \frac{1}{N}\sum |y_i - \hat{y}_i|$, is less sensitive to outliers.
+
+5.  **MLP for Image Classification (10 Categories):**
+    *   **Output Layer Setup:**
+        *   **Number of Nodes:** 10 nodes, one for each category. Each node will output a score or probability associated with its corresponding class.
+        *   **Activation Function:** **Softmax activation function**. Softmax takes the raw output scores (logits) from the 10 nodes and converts them into a probability distribution, where each output is between 0 and 1, and all 10 outputs sum to 1. This gives the model's confidence for each class.
+    *   **Suitable Loss Function:** **Cross-Entropy Loss** (specifically, Categorical Cross-Entropy). This loss function is designed for multi-class classification problems where the output is a probability distribution. It measures the dissimilarity between the predicted probability distribution (from softmax) and the true distribution (which is typically a one-hot encoded vector with 1 for the true class and 0 for others).
+
+### Solutions to Calculation Questions
+
+**Question 1 (Network Parameters):**
+*   Input layer: 10 nodes ($n_0 = 10$)
+*   Hidden layer: 20 nodes ($n_1 = 20$)
+*   Output layer: 5 nodes ($n_2 = 5$)
+
+**Parameters between Input and Hidden Layer:**
+*   Weights ($W^{(1)}$): The weight matrix connecting $n_0$ input nodes to $n_1$ hidden nodes will have dimensions $n_0 \times n_1$ (or $n_1 \times n_0$). If $W^{(1)}$ is $n_1 \times n_0$, then number of weights = $n_1 \times n_0 = 20 \times 10 = 200$.
+*   Biases ($b^{(1)}$): Each of the $n_1$ hidden nodes has one bias term. Number of biases = $n_1 = 20$.
+*   Total parameters for hidden layer = $200 + 20 = 220$.
+
+**Parameters between Hidden and Output Layer:**
+*   Weights ($W^{(2)}$): The weight matrix connecting $n_1$ hidden nodes to $n_2$ output nodes will have dimensions $n_1 \times n_2$ (or $n_2 \times n_1$). If $W^{(2)}$ is $n_2 \times n_1$, then number of weights = $n_2 \times n_1 = 5 \times 20 = 100$.
+*   Biases ($b^{(2)}$): Each of the $n_2$ output nodes has one bias term. Number of biases = $n_2 = 5$.
+*   Total parameters for output layer = $100 + 5 = 105$.
+
+**Total Trainable Parameters:**
+Total = Parameters (Hidden Layer) + Parameters (Output Layer)
+Total = $220 + 105 = 325$.
+
+**Answer:** The total number of trainable parameters is 325.
+
+---
+
+**Question 2 (Forward and Backward Pass):**
+Given:
+$x = \begin{pmatrix} 10 \\ 50 \\ -20 \end{pmatrix}$, $y = 0$
+$W^{(1)} = \begin{pmatrix} 0.1 & 0.4 \\ 0.2 & 0.5 \\ 0.3 & 0.6 \end{pmatrix}$ (shape 3x2, so $W^{(1)T}$ will be used or inputs are rows of W)
+Let's assume the convention $z^{(1)} = x^T W^{(1)}$ if $x$ is a row vector, or $z^{(1)} = W^{(1)T} x$ if $x$ is a column vector and $W^{(1)}$ is (inputs x hidden_nodes).
+The problem states $W_{ij}^{(1)}$ is weight from input $i$ to hidden node $j$. This means $W^{(1)}$ is (input_dim x hidden_dim).
+So $z^{(1)} = x^T W^{(1)}$ is not standard. Standard for $x$ as column vector is $z^{(1)} = W^{(1)T} x$ or $z^{(1)} = W_{alt}^{(1)} x$ where $W_{alt}^{(1)}$ is (hidden_dim x input_dim).
+Given $W^{(1)}$ shape is (3,2), it implies $W^{(1)}_{input\_feature, hidden\_unit}$.
+So, $z^{(1)T} = x^T W^{(1)}$ or $z^{(1)} = W^{(1)T} x$.
+Let's use $z^{(l)} = W^{(l)T} h^{(l-1)} + b^{(l)}$ where $h^{(l-1)}$ is column vector.
+So for the first layer, $z^{(1)} = W^{(1)T} x + b^{(1)}$.
+$W^{(1)T} = \begin{pmatrix} 0.1 & 0.2 & 0.3 \\ 0.4 & 0.5 & 0.6 \end{pmatrix}$ (shape 2x3)
+$b^{(1)} = \begin{pmatrix} 0 \\ 0 \end{pmatrix}$
+
+$W^{(2)} = \begin{pmatrix} 0.7 \\ 0.8 \end{pmatrix}$ (shape 2x1)
+This means $W^{(2)T} = \begin{pmatrix} 0.7 & 0.8 \end{pmatrix}$ (shape 1x2)
+$b^{(2)} = \begin{pmatrix} 0 \end{pmatrix}$
+
+Activation functions: $f^{(1)}$ = ReLU, $f^{(2)}$ = Sigmoid.
+
+**a) Forward Pass:**
+
+*   **Hidden Layer Pre-activation ($z^{(1)}$):**
+    $z^{(1)} = W^{(1)T} x + b^{(1)}$
+    $z^{(1)} = \begin{pmatrix} 0.1 & 0.2 & 0.3 \\ 0.4 & 0.5 & 0.6 \end{pmatrix} \begin{pmatrix} 10 \\ 50 \\ -20 \end{pmatrix} + \begin{pmatrix} 0 \\ 0 \end{pmatrix}$
+    $z^{(1)}_1 = (0.1 \times 10) + (0.2 \times 50) + (0.3 \times -20) = 1 + 10 - 6 = 5$
+    $z^{(1)}_2 = (0.4 \times 10) + (0.5 \times 50) + (0.6 \times -20) = 4 + 25 - 12 = 17$
+    $z^{(1)} = \begin{pmatrix} 5 \\ 17 \end{pmatrix}$
+
+*   **Hidden Layer Activation ($h^{(1)}$):** (ReLU)
+    $h^{(1)} = \text{ReLU}(z^{(1)})$
+    $h^{(1)}_1 = \max(0, 5) = 5$
+    $h^{(1)}_2 = \max(0, 17) = 17$
+    $h^{(1)} = \begin{pmatrix} 5 \\ 17 \end{pmatrix}$
+
+*   **Output Layer Pre-activation ($z^{(2)}$):**
+    $z^{(2)} = W^{(2)T} h^{(1)} + b^{(2)}$
+    $z^{(2)} = \begin{pmatrix} 0.7 & 0.8 \end{pmatrix} \begin{pmatrix} 5 \\ 17 \end{pmatrix} + \begin{pmatrix} 0 \end{pmatrix}$
+    $z^{(2)} = (0.7 \times 5) + (0.8 \times 17) = 3.5 + 13.6 = 17.1$
+    $z^{(2)} = \begin{pmatrix} 17.1 \end{pmatrix}$
+
+*   **Final Prediction ($\hat{y}$):** (Sigmoid)
+    $\hat{y} = \sigma(z^{(2)}) = \frac{1}{1 + e^{-17.1}}$
+    $e^{-17.1} \approx 3.37 \times 10^{-8}$
+    $\hat{y} \approx \frac{1}{1 + 3.37 \times 10^{-8}} \approx \frac{1}{1.0000000337} \approx 0.999999966$
+    For simplicity in manual calculation, let's use a more rounded $\hat{y} \approx 1.0$ if $z^{(2)}$ were very large, but $17.1$ is finite.
+    $\hat{y} \approx 0.99999997$ (using a calculator)
+
+**Summary of Forward Pass:**
+$z^{(1)} = \begin{pmatrix} 5 \\ 17 \end{pmatrix}$
+$h^{(1)} = \begin{pmatrix} 5 \\ 17 \end{pmatrix}$
+$z^{(2)} = \begin{pmatrix} 17.1 \end{pmatrix}$
+$\hat{y} \approx 0.99999997$
+
+**b) Loss Calculation (MSE):**
+$L = \frac{1}{2} (\hat{y} - y)^2$
+$L = \frac{1}{2} (0.99999997 - 0)^2 = \frac{1}{2} (0.99999997)^2 \approx \frac{1}{2} (0.99999994) \approx 0.49999997$
+
+**c) Backward Pass:**
+
+*   **Error term for Output Layer ($\delta^{(2)}$):**
+    $\delta^{(2)} = (\hat{y} - y) \cdot f^{(2)'}(z^{(2)})$
+    $f^{(2)}(z) = \sigma(z)$, so $f^{(2)'}(z) = \sigma(z)(1-\sigma(z)) = \hat{y}(1-\hat{y})$
+    $\delta^{(2)} = (\hat{y} - y) \cdot \hat{y}(1-\hat{y})$
+    $\delta^{(2)} = (0.99999997 - 0) \cdot 0.99999997(1 - 0.99999997)$
+    $\delta^{(2)} = 0.99999997 \cdot 0.99999997 \cdot (0.00000003)$
+    $\delta^{(2)} \approx 1 \cdot 1 \cdot (3 \times 10^{-8}) = 3 \times 10^{-8}$
+    More precisely: $(0.999999966) \times (0.999999966) \times (1 - 0.999999966) \approx 0.999999932 \times 3.37 \times 10^{-8} \approx 3.369999 \times 10^{-8}$
+    Let $\delta^{(2)} \approx 3.37 \times 10^{-8}$
+
+*   **Gradients for $W^{(2)}$:**
+    $\frac{\partial L}{\partial W^{(2)}} = \delta^{(2)} h^{(1)T}$ (This is for $W^{(2)}$ being $n_2 \times n_1$. Our $W^{(2)}$ is $n_1 \times n_2 = 2 \times 1$. So $\frac{\partial L}{\partial W^{(2)}}$ should be $2 \times 1$)
+    The formula for $z^{(2)} = W^{(2)T}h^{(1)}$ means $\frac{\partial L}{\partial W^{(2)T}} = h^{(1)} \delta^{(2)T}$. So $\frac{\partial L}{\partial W^{(2)}} = (h^{(1)} \delta^{(2)T})^T = \delta^{(2)} h^{(1)T}$ if $\delta^{(2)}$ is a row vector.
+    If $z^{(2)} = W^{(2)T}h^{(1)}$ (scalar output), $W^{(2)}$ is $n_1 \times 1$ (a column vector), $h^{(1)}$ is $n_1 \times 1$.
+    $\frac{\partial z^{(2)}}{\partial W_k^{(2)}} = h_k^{(1)}$. So $\frac{\partial L}{\partial W_k^{(2)}} = \delta^{(2)} h_k^{(1)}$.
+    $\frac{\partial L}{\partial W^{(2)}} = h^{(1)} \delta^{(2)}$ (since $\delta^{(2)}$ is scalar here)
+    $\frac{\partial L}{\partial W^{(2)}} = \begin{pmatrix} 5 \\ 17 \end{pmatrix} \cdot (3.37 \times 10^{-8})$
+    $\frac{\partial L}{\partial W_{1}^{(2)}} = 5 \times 3.37 \times 10^{-8} = 1.685 \times 10^{-7}$
+    $\frac{\partial L}{\partial W_{2}^{(2)}} = 17 \times 3.37 \times 10^{-8} = 5.729 \times 10^{-7}$
+    $\frac{\partial L}{\partial W^{(2)}} = \begin{pmatrix} 1.685 \times 10^{-7} \\ 5.729 \times 10^{-7} \end{pmatrix}$
+
+*   **Error term for Hidden Layer ($\delta^{(1)}$):**
+    $\delta^{(1)} = (W^{(2)} \delta^{(2)}) \odot f^{(1)'}(z^{(1)})$ (General form $W^{(l+1)T}\delta^{(l+1)}$)
+    Here, $W^{(2)}$ is $2 \times 1$. $\delta^{(2)}$ is $1 \times 1$. $W^{(2)}\delta^{(2)}$ is $2 \times 1$.
+    $f^{(1)'}(z^{(1)})$ is the derivative of ReLU.
+    ReLU$' (z) = 1$ if $z > 0$, else $0$.
+    $z^{(1)} = \begin{pmatrix} 5 \\ 17 \end{pmatrix}$, so $f^{(1)'}(z^{(1)}) = \begin{pmatrix} 1 \\ 1 \end{pmatrix}$.
+    $\delta^{(1)} = \left( \begin{pmatrix} 0.7 \\ 0.8 \end{pmatrix} \cdot (3.37 \times 10^{-8}) \right) \odot \begin{pmatrix} 1 \\ 1 \end{pmatrix}$
+    $\delta^{(1)}_1 = 0.7 \times (3.37 \times 10^{-8}) \times 1 = 2.359 \times 10^{-8}$
+    $\delta^{(1)}_2 = 0.8 \times (3.37 \times 10^{-8}) \times 1 = 2.696 \times 10^{-8}$
+    $\delta^{(1)} = \begin{pmatrix} 2.359 \times 10^{-8} \\ 2.696 \times 10^{-8} \end{pmatrix}$
+
+*   **Gradients for $W^{(1)}$:**
+    $\frac{\partial L}{\partial W^{(1)}} = x \delta^{(1)T}$ (This is if $W^{(1)}$ is $n_0 \times n_1$. Our $W^{(1)}$ is $3 \times 2$)
+    The formula $z^{(1)} = W^{(1)T} x$ implies $\frac{\partial L}{\partial W^{(1)T}} = x \delta^{(1)T}$.
+    So $\frac{\partial L}{\partial W^{(1)}} = (\delta^{(1)} x^T)^T = x \delta^{(1)T}$ if $\delta^{(1)}$ is row vector.
+    If $W^{(1)}$ is $n_0 \times n_1$, then $z^{(1)}_j = \sum_k W_{kj}^{(1)} x_k$. $\frac{\partial z_j^{(1)}}{\partial W_{ki}^{(1)}} = x_k \delta_{ji}$.
+    The gradient $\frac{\partial L}{\partial W^{(1)}}$ should have the same shape as $W^{(1)}$, which is $3 \times 2$.
+    $\frac{\partial L}{\partial W_{ij}^{(1)}} = x_i \delta_j^{(1)}$.
+    $\frac{\partial L}{\partial W^{(1)}} = x \delta^{(1)T} = \begin{pmatrix} 10 \\ 50 \\ -20 \end{pmatrix} \begin{pmatrix} 2.359 \times 10^{-8} & 2.696 \times 10^{-8} \end{pmatrix}$
+    $\frac{\partial L}{\partial W_{11}^{(1)}} = 10 \times (2.359 \times 10^{-8}) = 2.359 \times 10^{-7}$
+    $\frac{\partial L}{\partial W_{12}^{(1)}} = 10 \times (2.696 \times 10^{-8}) = 2.696 \times 10^{-7}$
+    $\frac{\partial L}{\partial W_{21}^{(1)}} = 50 \times (2.359 \times 10^{-8}) = 1.1795 \times 10^{-6}$
+    $\frac{\partial L}{\partial W_{22}^{(1)}} = 50 \times (2.696 \times 10^{-8}) = 1.348 \times 10^{-6}$
+    $\frac{\partial L}{\partial W_{31}^{(1)}} = -20 \times (2.359 \times 10^{-8}) = -4.718 \times 10^{-7}$
+    $\frac{\partial L}{\partial W_{32}^{(1)}} = -20 \times (2.696 \times 10^{-8}) = -5.392 \times 10^{-7}$
+
+    $\frac{\partial L}{\partial W^{(1)}} = \begin{pmatrix}
+    2.359 \times 10^{-7} & 2.696 \times 10^{-7} \\
+    1.1795 \times 10^{-6} & 1.348 \times 10^{-6} \\
+    -4.718 \times 10^{-7} & -5.392 \times 10^{-7}
+    \end{pmatrix}$
+
+**Summary of Backward Pass Gradients:**
+$\delta^{(2)} \approx 3.37 \times 10^{-8}$
+$\frac{\partial L}{\partial W^{(2)}} = \begin{pmatrix} 1.685 \times 10^{-7} \\ 5.729 \times 10^{-7} \end{pmatrix}$
+$\delta^{(1)} = \begin{pmatrix} 2.359 \times 10^{-8} \\ 2.696 \times 10^{-8} \end{pmatrix}$
+$\frac{\partial L}{\partial W^{(1)}} = \begin{pmatrix}
+2.359 \times 10^{-7} & 2.696 \times 10^{-7} \\
+1.1795 \times 10^{-6} & 1.348 \times 10^{-6} \\
+-4.718 \times 10^{-7} & -5.392 \times 10^{-7}
+\end{pmatrix}$
+(Biases were zero, so gradients for biases are not explicitly asked but would be $\delta^{(2)}$ and $\delta^{(1)}$ respectively.)


### PR DESCRIPTION
This commit includes three main artifacts:

1.  `mlp_lecture_notes.md`: Comprehensive lecture notes on Multi-Layer Perceptrons, covering theory, architecture, activation functions, and backpropagation with LaTeX for mathematical formulas.
2.  `mlp_practice_exam.md`: A practice exam with conceptual and calculation questions (including a full forward/backward pass example), complete with detailed solutions.
3.  `mlp_from_scratch.ipynb`: A Jupyter Notebook implementing an MLP from scratch using NumPy for a regression task, based on parameters from the provided exercise materials. Includes model definition, training loop, and loss visualization.

These files were generated based on the specifications provided in the project brief, referencing the supplied PDF documents on MLPs.